### PR TITLE
Fix .markup.bold font-style property

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -255,7 +255,7 @@
 .markup {
   &.bold {
     color: @orange;
-    font-style: bold;
+    font-weight: bold;
   }
 
   &.changed {


### PR DESCRIPTION
The property name was wrong for the `bold` value.

This is not an important fix but I noticed it while creating a syntax theme this weekend :smile:

I hope this is the package used in Atom's package-generator.
