### PR TITLE
Remove DS_Store from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-.DS_Store
 npm-debug.log
 node_modules


### PR DESCRIPTION
DS_Store belongs in the user's global gitignore file, rather than the project gitignore.

(This was taken from my previous issue, which was in the wrong location at package-generator)

The default `.gitignore` file includes .DS_Store. According to GitHub and most people, this should be in the user's global gitignore rather than project gitignores.

Sources:
- github/gitignore#1638
- github/gitignore#1591
- github/gitignore#1458
- github/gitignore#1256
- github/gitignore#1381
- github/gitignore#1155
- [and a search for all DS_Store related things in the gitignore repo](https://github.com/github/gitignore/search?p=1&q=ds_Store&type=Issues&utf8=%E2%9C%93)
- [and a blog post about this](http://www.zell-weekeat.com/gitignore/)
